### PR TITLE
Add private groups to channels view and throw fatal errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swp
 *.swo
 node_modules/
+npm-debug.log
+error_log.txt

--- a/main.js
+++ b/main.js
@@ -80,9 +80,13 @@ function formatMessageMentions(text) {
   }
 
   // find special words
-  return formattedText.replace(
-    /<!channel>/g,
-    '{yellow-fg}@channel{/yellow-fg}');
+  return formattedText
+    .replace(
+      /<!channel>/g,
+      '{yellow-fg}@channel{/yellow-fg}')
+    .replace(
+      /<!everyone>/g,
+      '{yellow-fg}@everyone{/yellow-fg}');
 }
 
 function handleNewMessage(message) {
@@ -188,7 +192,7 @@ slack.getChannels((error, response, data) => {
   }
 
   const channelData = JSON.parse(data);
-  channels = channelData.channels.filter(channel => !channel.is_archived);
+  channels = channelData.channels.filter(channel => !channel.is_archived && !channel.is_mpim);
 
   components.channelList.setItems(
     channels.map(slackChannel => slackChannel.name)

--- a/slackClient.js
+++ b/slackClient.js
@@ -5,7 +5,7 @@ const TOKEN = process.env.SLACK_TOKEN;
 
 if (TOKEN === undefined) {
   const throwError = 'Error: SLACK_TOKEN undefined. Please add SLACK_TOKEN to the environment variables.';
-  throw throwError;
+  throw new Error(throwError);
 }
 
 // makes a request to slack. Adds token to query
@@ -17,19 +17,19 @@ function slackRequest(endpoint, query, callback) {
     qs,
   }, (error, response, data) => {
     if (error) {
-      throw error;
+      throw new Error(error);
     }
 
     if (response.statusCode !== 200) {
       const logError = `Response Error: ${response.statusCode}`;
-      throw logError;
+      throw new Error(logError);
     }
 
     const parsedData = JSON.parse(data);
     // name_taken is expected if trying to channels.join on a group
     if (!parsedData.ok && !(endpoint === 'channels.join' && parsedData.error === 'name_taken')) {
       const logError = `Error: ${parsedData.error}`;
-      throw logError;
+      throw new Error(logError);
     }
 
     if (callback) {

--- a/slackClient.js
+++ b/slackClient.js
@@ -1,14 +1,11 @@
-const fs = require('fs');
 const request = require('request');
 const WebSocket = require('ws');
 
 const TOKEN = process.env.SLACK_TOKEN;
 
 if (TOKEN === undefined) {
-  console.log( // eslint-disable-line no-console
-    'Error: SLACK_TOKEN undefined. Please add SLACK_TOKEN to the environment variables.'
-  );
-  process.exit(1);
+  const throwError = 'Error: SLACK_TOKEN undefined. Please add SLACK_TOKEN to the environment variables.';
+  throw throwError;
 }
 
 // makes a request to slack. Adds token to query
@@ -20,21 +17,19 @@ function slackRequest(endpoint, query, callback) {
     qs,
   }, (error, response, data) => {
     if (error) {
-      fs.writeFileSync('error_log.txt', error);
-      process.exit(1);
+      throw error;
     }
 
     if (response.statusCode !== 200) {
-      fs.writeFileSync('error_log.txt', `Response Error: ${response.statusCode}`);
-      process.exit(1);
+      const logError = `Response Error: ${response.statusCode}`;
+      throw logError;
     }
 
     const parsedData = JSON.parse(data);
     // name_taken is expected if trying to channels.join on a group
     if (!parsedData.ok && !(endpoint === 'channels.join' && parsedData.error === 'name_taken')) {
-      // can't see console.logs with blessed
-      fs.writeFileSync('error_log.txt', `Error: ${parsedData.error}`);
-      process.exit(1);
+      const logError = `Error: ${parsedData.error}`;
+      throw logError;
     }
 
     if (callback) {


### PR DESCRIPTION
Hey,

Since most of my use of slack is in private channels, I decided to add a feature for it. I've implemented it by changing the slackClient so I could keep the amount of files changed to a minimum. I also realise that checking for an error to see if it's a group isn't the best of solutions but it's the only one I could think of.

I've also added a second commit where I changed the error logging from logging to a file to throwing the error message. If you don't agree with that I can change to PR to just be the first commit.

Tell me what you think.

EDIT: After noticing that the slack api doesn't react well with multi-user direct message channel names I removed them with the same filter for removing archived channels.

Thanks, Brian