### PR TITLE
Fix empty submit

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,6 +138,12 @@ slack.init((data, ws) => {
 
   // event handler when message is submitted
   components.messageInput.on('submit', (text) => {
+    if (!text || !text.length) {
+        components.messageInput.clearValue();
+        components.messageInput.focus();
+        return;
+    }
+
     const id = getNextId();
     components.messageInput.clearValue();
     components.messageInput.focus();


### PR DESCRIPTION
When a user submits an empty message repeatedly, the app crashes