### PR TITLE
Ignore lock and log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
+# Editor/OS-specific files
 .DS_STORE
 *.swp
 *.swo
+
+# Log files
+npm-debug.log*
+
+# Vendor files
 node_modules/
+
+# Npm lock file (https://docs.npmjs.com/files/package-lock.json)
+package-lock.json
+
+# Yarn lock file (https://yarnpkg.com)
+yarn.lock


### PR DESCRIPTION
Ignore lock files and npm error logs.

Since you don't have any lock files committed for this repo currently, I'm guessing you don't use them.
Lock files are only useful for teams that enforce use of a specific package manager version. Otherwise, they pollute the commit history. Locking package versions in package.json is a simpler alternative for avoiding breaking changes in dependencies.