### PR TITLE
Oauth local server and tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.swp
 *.swo
 node_modules/
+config.json
+server/slack-config*.json
+error_log.txt
+package-lock.json

--- a/readme.md
+++ b/readme.md
@@ -38,18 +38,28 @@ A terminal interface for Slack.
 	npm install
 	```
 	
-4. Create your Legacy Slack API token.
+4. Create your Slack OAUth token. You'll need to make an app to hand out this token since you shouldn't trust anyone on the internet to generate one:
 
-	- Go to the [Slack Legacy Tokens](https://api.slack.com/custom-integrations/legacy-tokens) page
-	- Click **Generate Token**
-
-5. Install your token on your local machine, inserting your token between the quotes:
-
+  - Make yourself a new slack app at https://api.slack.com/apps call it something like 'my textmode'
+  - Set redirect url: `http://localhost:8080/textmode`
+  - Set scope: `channels:history` (doesn't actually matter, but needs at least one)
+  - Save the *client ID*, and *client secret*
+  - Add the slack app to your (a) workspace.
+	- Install and run the local server replacing values as saved above:
 	```
-	export SLACK_TOKEN='your-slack-token-here'
-	```
+	  cd server
+	  npm install
+	  CLIENT_ID=your-client-id CLIENT_SECRET=your-client-scret REDIRECT_URI=http://localhost:8080/textmode node server.js
+  ```
+	- Open http://localhost:8080/auth
+	- Follow the link, auth to slack.
+	- Your token is now pasted to screen and saved in ./slack-config.{workspace}.json
+  - On success, close browser window .
+	- Stop the server (ctrl-c)
+	- `cp slack-config.{workspace}.json ../config.json`
+	- Done! 
 
-6. Run the application: 
+5. Run the application: 
 
 	```
 	node main.js
@@ -60,8 +70,4 @@ A terminal interface for Slack.
 ## Troubleshooting
  - **Terminal Slack opens for a second but then closes again**
 
- 	This might be due to your `SLACK_TOKEN` not being recognised. Make sure the put your `SLACK_TOKEN` between the two single quotes when exporting it:
- 	
- 	```
- 	export SLACK_TOKEN='xoxp-254112160503-252950188691-252375361712-6cbf56aada30951a9d310a5f23d032a0'
- 	```
+ 	Make sure you have a fresh token by following oauth instructions above.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "terminal-slack-server",
+  "version": "1.0.0",
+  "description": "oauth token local server for slack-terminal",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "author": "courtenay",
+  "license": "MIT",
+  "keywords": [],
+  "dependencies": {
+    "express": "^4.16.2",
+    "sanitize-filename": "^1.6.1"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,46 @@
+const request = require('request')
+const express = require('express')
+const app = express()
+const sanitize = require('sanitize-filename')
+
+const fs = require('fs')
+
+app.get('/', (req, res) => { 
+  res.send(
+    `Get your oauth token here. <a href='/auth'>Auth me</a> ${process.env.REDIRECT_URI}`)
+})
+
+app.get('/auth', (req, res) => {
+  scopes = ["client"]
+  res.send(`<a href="https://slack.com/oauth/authorize?scope=${scopes.join(' ')}&client_id=${process.env.CLIENT_ID}"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>`)
+})
+
+app.get('/textmode', (req, res) => {
+  var options = {
+    uri: 'https://slack.com/api/oauth.access?code=' + req.query.code +
+      `&client_id=${process.env.CLIENT_ID}` +
+      `&client_secret=${process.env.CLIENT_SECRET}` +
+      `&redirect_uri=${process.env.REDIRECT_URI}`,
+      method: 'GET'
+    }
+  request(options, (err, resp, body) => {
+    var JSONResponse = JSON.parse(body)
+    if (!JSONResponse.ok) { 
+      console.log(JSONResponse)
+      res.send("Error encountered. <a href='/auth'>Try again</a>: \n" + JSON.stringify(JSONResponse)).status(200).end()
+    } else {
+      console.log(JSONResponse)
+      res.send("JSON Response success. Your token is " + JSONResponse.access_token + 
+        " - Check your server localpath for the config file or JSON. (You can close this window.")
+      fs.writeFile(`slack-config.${sanitize(JSONResponse.team_name)}.json`,
+        JSON.stringify(JSONResponse), (err) => { 
+          if (err) { console.log(`Could not save file: ${err}`) }
+        }
+      )
+    }
+  })
+  
+})
+
+console.log("Local server starting..")
+app.listen(8080, () => console.log("Listening on port 8080. Open a browser: http://localhost:8080/"))


### PR DESCRIPTION
Because legacy tokens are (probably) a bad idea! So here are instructions
for making your own slack app and handing out your own oauth tokens (so
you control them) We then run a web server on localhost that you can shut
down after you have the token. (You could also run this on a server somewhere
and authenticate people in your workspace).

also makes the tokens stored in a config file instead of variables. ymmv.